### PR TITLE
fix: internal improvements (6 issues)

### DIFF
--- a/src/AuditLogger.php
+++ b/src/AuditLogger.php
@@ -212,13 +212,14 @@ final readonly class AuditLogger implements AuditLoggerInterface
     public function verify(AuditLogResult $result): bool
     {
         try {
-            $dataJson = json_encode([
-                'meta' => [
-                    'user_agent' => $result->userAgent,
-                    'timestamp'  => $result->timestamp->format(self::TIMESTAMP_FORMAT),
-                ],
-                'data' => $result->data,
-            ], JSON_THROW_ON_ERROR);
+            $dataJson = json_encode(
+                $this->buildEnvelope(
+                    $result->userAgent,
+                    $result->timestamp->format(self::TIMESTAMP_FORMAT),
+                    $result->data,
+                ),
+                JSON_THROW_ON_ERROR,
+            );
         } catch (JsonException) {
             return false;
         }
@@ -249,18 +250,30 @@ final readonly class AuditLogger implements AuditLoggerInterface
     }
 
     /**
+     * @param array<string, mixed>|null $data
+     * @return array{meta: array{user_agent: string, timestamp: string}, data: array<string, mixed>|null}
+     */
+    private function buildEnvelope(string $userAgent, string $timestamp, ?array $data): array
+    {
+        return [
+            'meta' => [
+                'user_agent' => $userAgent,
+                'timestamp'  => $timestamp,
+            ],
+            'data' => $data,
+        ];
+    }
+
+    /**
      * @throws StorageException
      */
     private function encodeData(AuditLogEntry $entry, string $timestamp): string
     {
         try {
-            return json_encode([
-                'meta' => [
-                    'user_agent' => $entry->userAgent,
-                    'timestamp'  => $timestamp,
-                ],
-                'data' => $entry->data,
-            ], JSON_THROW_ON_ERROR);
+            return json_encode(
+                $this->buildEnvelope($entry->userAgent, $timestamp, $entry->data),
+                JSON_THROW_ON_ERROR,
+            );
         } catch (JsonException $jsonException) {
             throw new StorageException('Failed to encode audit data as JSON: ' . $jsonException->getMessage(), 0, $jsonException);
         }

--- a/src/AuditLogger.php
+++ b/src/AuditLogger.php
@@ -561,6 +561,10 @@ final readonly class AuditLogger implements AuditLoggerInterface
      */
     private function validateIdentifier(string $identifier): string
     {
+        if (strlen($identifier) > 64) {
+            throw new StorageException('Table name exceeds maximum length of 64 characters: ' . $identifier);
+        }
+
         if (preg_match('/^[a-zA-Z_]\w*$/', $identifier) !== 1) {
             throw new StorageException('Invalid table name: ' . $identifier);
         }

--- a/src/AuditLogger.php
+++ b/src/AuditLogger.php
@@ -358,7 +358,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
 
         $logDir = dirname($this->logFilePath);
         /** @infection-ignore-all: Permission value and mkdir failure path untestable without filesystem mocking */
-        if (!is_dir($logDir) && (!mkdir($logDir, 0755, true) && !is_dir($logDir))) {
+        if (!is_dir($logDir) && (!mkdir($logDir, 0700, true) && !is_dir($logDir))) {
             throw new StorageException('Failed to create log directory: ' . $logDir);
         }
 

--- a/src/AuditLogger.php
+++ b/src/AuditLogger.php
@@ -117,7 +117,12 @@ final readonly class AuditLogger implements AuditLoggerInterface
             throw new StorageException('Failed to write audit log to database: ' . $pdoException->getMessage(), 0, $pdoException);
         }
 
-        $this->writeToFile($timestamp, $entry, $checksum);
+        try {
+            $this->writeToFile($timestamp, $entry, $checksum);
+        } catch (AuditLogException) {
+            // Silently ignore file write failures after successful database write.
+            // The file log is a redundant fallback — the audit entry is already persisted.
+        }
     }
 
     /**

--- a/src/AuditLogger.php
+++ b/src/AuditLogger.php
@@ -32,6 +32,8 @@ final readonly class AuditLogger implements AuditLoggerInterface
 
     private const string HMAC_HKDF_INFO = 'audit-logger-hmac';
 
+    private const string TIMESTAMP_FORMAT = 'Y-m-d H:i:s';
+
     private const int MAX_ENCODED_DATA_SIZE = 10_000;
 
     private bool $useDbEncryption;
@@ -87,7 +89,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
      */
     public function log(AuditLogEntry $entry): void
     {
-        $timestamp = (new DateTimeImmutable())->format('Y-m-d H:i:s');
+        $timestamp = (new DateTimeImmutable())->format(self::TIMESTAMP_FORMAT);
         $dataJson  = $this->encodeData($entry, $timestamp);
 
         if (strlen($dataJson) > self::MAX_ENCODED_DATA_SIZE) {
@@ -213,7 +215,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
             $dataJson = json_encode([
                 'meta' => [
                     'user_agent' => $result->userAgent,
-                    'timestamp'  => $result->timestamp->format('Y-m-d H:i:s'),
+                    'timestamp'  => $result->timestamp->format(self::TIMESTAMP_FORMAT),
                 ],
                 'data' => $result->data,
             ], JSON_THROW_ON_ERROR);
@@ -224,7 +226,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
         $expected = hash_hmac(
             'sha256',
             $this->buildChecksumInput(
-                $result->timestamp->format('Y-m-d H:i:s'),
+                $result->timestamp->format(self::TIMESTAMP_FORMAT),
                 $result->userId,
                 $result->ipAddress,
                 $result->action,

--- a/src/AuditLogger.php
+++ b/src/AuditLogger.php
@@ -73,7 +73,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
             throw new InvalidArgumentException('Max limit must be at least 1');
         }
 
-        $this->escapeIdentifier($tableName);
+        $this->validateIdentifier($tableName);
 
         $this->useDbEncryption  = $encryption instanceof DatabaseEncryption;
         $this->fileEncryption   = $this->useDbEncryption ? new AppEncryption() : $encryption;
@@ -325,7 +325,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
         string $dataJson,
         string $checksum,
     ): void {
-        $table = $this->escapeIdentifier($this->tableName);
+        $table = $this->validateIdentifier($this->tableName);
 
         if ($this->useDbEncryption) {
             $sql = "
@@ -427,7 +427,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
             throw new InvalidArgumentException('Limit must not exceed ' . $this->maxLimit);
         }
 
-        $table = $this->escapeIdentifier($this->tableName);
+        $table = $this->validateIdentifier($this->tableName);
 
         if ($this->useDbEncryption) {
             $sql = "
@@ -555,11 +555,11 @@ final readonly class AuditLogger implements AuditLoggerInterface
     }
 
     /**
-     * Escape a SQL identifier (table name) to prevent injection
+     * Validate a SQL identifier (table name) to prevent injection
      *
      * @throws StorageException
      */
-    private function escapeIdentifier(string $identifier): string
+    private function validateIdentifier(string $identifier): string
     {
         if (preg_match('/^[a-zA-Z_]\w*$/', $identifier) !== 1) {
             throw new StorageException('Invalid table name: ' . $identifier);

--- a/tests/AuditLoggerWriteTest.php
+++ b/tests/AuditLoggerWriteTest.php
@@ -627,6 +627,45 @@ final class AuditLoggerWriteTest extends TestCase
     }
 
     /**
+     * Test that validateIdentifier accepts table names at exactly 64 characters (boundary).
+     */
+    #[Test]
+    public function testConstructorAcceptsTableNameAtMaxLength(): void
+    {
+        $pdo  = $this->createStub(PDO::class);
+        $name = str_repeat('a', 64);
+
+        $logger = new AuditLogger(
+            pdo: $pdo,
+            encryptionKey: $this->encryptionKey,
+            encryption: new DatabaseEncryption(),
+            tableName: $name,
+        );
+
+        $this->assertInstanceOf(AuditLogger::class, $logger);
+    }
+
+    /**
+     * Test that validateIdentifier rejects table names exceeding 64 characters.
+     */
+    #[Test]
+    public function testConstructorRejectsTableNameExceedingMaxLength(): void
+    {
+        $pdo  = $this->createStub(PDO::class);
+        $name = str_repeat('a', 65);
+
+        $this->expectException(StorageException::class);
+        $this->expectExceptionMessage('Table name exceeds maximum length of 64 characters: ' . $name);
+
+        new AuditLogger(
+            pdo: $pdo,
+            encryptionKey: $this->encryptionKey,
+            encryption: new DatabaseEncryption(),
+            tableName: $name,
+        );
+    }
+
+    /**
      * Test file log contains timestamp field (kills mutant #36: ArrayItemRemoval of timestamp).
      */
     #[Test]


### PR DESCRIPTION
## Summary
Six internal fixes and refactors — no public API changes.

- **#16** — `writeToFile()` no longer propagates exceptions after successful DB write
- **#5** — Log directory permissions changed from `0755` to `0700` (consistent with `0600` file perms)
- **#10** — Extracted timestamp format `'Y-m-d H:i:s'` as `TIMESTAMP_FORMAT` class constant
- **#13** — Extracted `buildEnvelope()` helper to DRY the `['meta' => ..., 'data' => ...]` structure
- **#14** — Renamed `escapeIdentifier()` to `validateIdentifier()` (method validates, not escapes)
- **#15** — Added 64-character length limit to `validateIdentifier()`

Each commit maps 1:1 to an issue. **Please use Rebase Merge** (not Squash) to preserve individual commits.

Closes #16, closes #5, closes #10, closes #13, closes #14, closes #15

## Test plan
- [x] All 151 tests pass
- [x] `make check` passes (CS-Fixer, PHPStan, Psalm, PHPMD, Rector, Deptrac, PHPUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)