### PR TITLE
refactor: extract shared result-mapping logic into ResultMapper

### DIFF
--- a/src/AuditLogger.php
+++ b/src/AuditLogger.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Zappzarapp\AuditLogger;
 
-use DateMalformedStringException;
 use DateTimeImmutable;
 use InvalidArgumentException;
 use JsonException;
@@ -468,20 +467,6 @@ final readonly class AuditLogger implements AuditLoggerInterface
             throw new StorageException('Failed to query audit logs: ' . $pdoException->getMessage(), 0, $pdoException);
         }
 
-        return $this->mapResults($rows);
-    }
-
-    /**
-     * Map raw database rows to AuditLogResult DTOs
-     *
-     * @param array<int, array<string, mixed>> $rows
-     * @return AuditLogResult[]
-     *
-     * @throws EncryptionException
-     * @throws StorageException
-     */
-    private function mapResults(array $rows): array
-    {
         return array_map($this->mapRow(...), $rows);
     }
 
@@ -493,11 +478,9 @@ final readonly class AuditLogger implements AuditLoggerInterface
      */
     private function mapRow(array $row): AuditLogResult
     {
-        $this->validateRowSchema($row);
-
         $dataString = $this->useDbEncryption
             ? ($row['data_decrypted'] ?? null)
-            : ($row['data'] !== null ? $this->encryption->decrypt((string) $row['data'], $this->encryptionKey) : null);
+            : (($row['data'] ?? null) !== null ? $this->encryption->decrypt((string) $row['data'], $this->encryptionKey) : null);
 
         $data      = null;
         $dataError = null;
@@ -517,41 +500,10 @@ final readonly class AuditLogger implements AuditLoggerInterface
             }
         }
 
-        try {
-            $timestamp = new DateTimeImmutable((string) $row['timestamp']);
-        } catch (DateMalformedStringException $dateMalformedStringException) {
-            throw new StorageException('Invalid timestamp in audit log: ' . $dateMalformedStringException->getMessage(), 0, $dateMalformedStringException);
-        }
+        $row['user_agent'] = $userAgent;
+        $row['data']       = $data;
 
-        return new AuditLogResult(
-            id: (int) $row['id'],
-            timestamp: $timestamp,
-            userId: $row['user_id'] !== null ? (int) $row['user_id'] : null,
-            ipAddress: (string) $row['ip_address'],
-            userAgent: $userAgent,
-            action: (string) $row['action'],
-            entityType: (string) $row['entity_type'],
-            entityId: (string) $row['entity_id'],
-            data: $data,
-            checksum: (string) $row['checksum'],
-            dataError: $dataError,
-        );
-    }
-
-    /**
-     * Validate that a database row contains all required fields
-     *
-     * @param array<string, mixed> $row
-     *
-     * @throws StorageException
-     */
-    private function validateRowSchema(array $row): void
-    {
-        $requiredKeys = ['id', 'timestamp', 'user_id', 'ip_address', 'action', 'entity_type', 'entity_id', 'checksum'];
-        $missingKeys  = array_diff($requiredKeys, array_keys($row));
-        if ($missingKeys !== []) {
-            throw new StorageException('Missing required fields in audit log row: ' . implode(', ', $missingKeys));
-        }
+        return ResultMapper::map($row, 'audit log row', $dataError);
     }
 
     /**

--- a/src/FileLogReader.php
+++ b/src/FileLogReader.php
@@ -6,8 +6,6 @@ declare(strict_types=1);
 
 namespace Zappzarapp\AuditLogger;
 
-use DateMalformedStringException;
-use DateTimeImmutable;
 use JsonException;
 use Zappzarapp\AuditLogger\Encryption\EncryptionInterface;
 use Zappzarapp\AuditLogger\Exception\EncryptionException;
@@ -79,34 +77,8 @@ final readonly class FileLogReader
             throw new StorageException('Corrupted JSON in file log line ' . $lineNumber . ': expected object');
         }
 
-        $requiredKeys = ['timestamp', 'user_id', 'ip_address', 'user_agent', 'action', 'entity_type', 'entity_id', 'checksum'];
-        $missingKeys  = array_diff($requiredKeys, array_keys($row));
-        if ($missingKeys !== []) {
-            throw new StorageException('Missing required fields in file log line ' . $lineNumber . ': ' . implode(', ', $missingKeys));
-        }
+        $row['id'] = $lineNumber;
 
-        try {
-            $timestamp = new DateTimeImmutable((string) $row['timestamp']);
-        } catch (DateMalformedStringException $dateMalformedStringException) {
-            throw new StorageException(
-                'Invalid timestamp in file log line ' . $lineNumber . ': ' . $dateMalformedStringException->getMessage(),
-                0,
-                $dateMalformedStringException,
-            );
-        }
-
-        return new AuditLogResult(
-            id: $lineNumber,
-            timestamp: $timestamp,
-            /** @infection-ignore-all: CastInt is defensive — json_decode already returns int for JSON integers */
-            userId: $row['user_id'] !== null ? (int) $row['user_id'] : null,
-            ipAddress: (string) $row['ip_address'],
-            userAgent: (string) $row['user_agent'],
-            action: (string) $row['action'],
-            entityType: (string) $row['entity_type'],
-            entityId: (string) $row['entity_id'],
-            data: is_array($row['data'] ?? null) ? $row['data'] : null,
-            checksum: (string) $row['checksum'],
-        );
+        return ResultMapper::map($row, 'file log line ' . $lineNumber);
     }
 }

--- a/src/ResultMapper.php
+++ b/src/ResultMapper.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\AuditLogger;
+
+use DateMalformedStringException;
+use DateTimeImmutable;
+use Zappzarapp\AuditLogger\Exception\StorageException;
+
+/**
+ * Maps normalized row data to AuditLogResult DTOs
+ *
+ * Shared mapping logic used by both AuditLogger (database) and FileLogReader (file fallback).
+ */
+final class ResultMapper
+{
+    private const array REQUIRED_KEYS = [
+        'id',
+        'timestamp',
+        'user_id',
+        'ip_address',
+        'user_agent',
+        'action',
+        'entity_type',
+        'entity_id',
+        'checksum',
+    ];
+
+    /**
+     * Map a normalized row to an AuditLogResult
+     *
+     * @param array<string, mixed> $row Normalized row containing all required keys
+     * @param string $errorContext Context for error messages (e.g. 'audit log row', 'file log line 5')
+     * @param string|null $dataError Error message when data JSON was corrupt
+     *
+     * @throws StorageException
+     */
+    public static function map(array $row, string $errorContext, ?string $dataError = null): AuditLogResult
+    {
+        self::validateSchema($row, $errorContext);
+
+        return new AuditLogResult(
+            id: (int) $row['id'],
+            timestamp: self::parseTimestamp((string) $row['timestamp'], $errorContext),
+            /** @infection-ignore-all: CastInt is defensive — value is always int from DB/JSON */
+            userId: $row['user_id'] !== null ? (int) $row['user_id'] : null,
+            ipAddress: (string) $row['ip_address'],
+            userAgent: (string) $row['user_agent'],
+            action: (string) $row['action'],
+            entityType: (string) $row['entity_type'],
+            entityId: (string) $row['entity_id'],
+            data: is_array($row['data'] ?? null) ? $row['data'] : null,
+            checksum: (string) $row['checksum'],
+            dataError: $dataError,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @throws StorageException
+     */
+    private static function validateSchema(array $row, string $errorContext): void
+    {
+        $missingKeys = array_diff(self::REQUIRED_KEYS, array_keys($row));
+        if ($missingKeys !== []) {
+            throw new StorageException('Missing required fields in ' . $errorContext . ': ' . implode(', ', $missingKeys));
+        }
+    }
+
+    /**
+     * @throws StorageException
+     */
+    private static function parseTimestamp(string $timestamp, string $errorContext): DateTimeImmutable
+    {
+        try {
+            return new DateTimeImmutable($timestamp);
+        } catch (DateMalformedStringException $dateMalformedStringException) {
+            throw new StorageException(
+                'Invalid timestamp in ' . $errorContext . ': ' . $dateMalformedStringException->getMessage(),
+                0,
+                $dateMalformedStringException,
+            );
+        }
+    }
+}

--- a/tests/AuditLoggerReadTest.php
+++ b/tests/AuditLoggerReadTest.php
@@ -314,7 +314,7 @@ final class AuditLoggerReadTest extends TestCase
         );
 
         $this->expectException(StorageException::class);
-        $this->expectExceptionMessage('Invalid timestamp in audit log');
+        $this->expectExceptionMessage('Invalid timestamp in audit log row');
 
         $logger->getLogsForEntity(entityType: 'test', entityId: 1);
     }
@@ -388,11 +388,11 @@ final class AuditLoggerReadTest extends TestCase
             $logger->getLogsForEntity(entityType: 'test', entityId: 1);
             $this->fail('Expected StorageException was not thrown');
         } catch (StorageException $storageException) {
-            $this->assertStringStartsWith('Invalid timestamp in audit log: ', $storageException->getMessage());
+            $this->assertStringStartsWith('Invalid timestamp in audit log row: ', $storageException->getMessage());
             $this->assertSame(0, $storageException->getCode());
             // The exception message should include the DateMalformedStringException message
             $this->assertGreaterThan(
-                strlen('Invalid timestamp in audit log: '),
+                strlen('Invalid timestamp in audit log row: '),
                 strlen($storageException->getMessage()),
             );
         }

--- a/tests/ResultMapperTest.php
+++ b/tests/ResultMapperTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\AuditLogger\Tests;
+
+use DateMalformedStringException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zappzarapp\AuditLogger\AuditLogResult;
+use Zappzarapp\AuditLogger\Exception\StorageException;
+use Zappzarapp\AuditLogger\ResultMapper;
+
+#[CoversClass(ResultMapper::class)]
+final class ResultMapperTest extends TestCase
+{
+    /**
+     * @return array<string, mixed>
+     */
+    private function validRow(): array
+    {
+        return [
+            'id'          => 1,
+            'timestamp'   => '2026-02-15 12:00:00',
+            'user_id'     => 42,
+            'ip_address'  => '127.0.0.1',
+            'user_agent'  => 'PHPUnit',
+            'action'      => 'user.login',
+            'entity_type' => 'auth',
+            'entity_id'   => '42',
+            'data'        => ['key' => 'value'],
+            'checksum'    => 'abc123',
+        ];
+    }
+
+    #[Test]
+    public function testMapReturnsAuditLogResult(): void
+    {
+        $result = ResultMapper::map($this->validRow(), 'test context');
+
+        $this->assertInstanceOf(AuditLogResult::class, $result);
+        $this->assertSame(1, $result->id);
+        $this->assertSame('2026-02-15 12:00:00', $result->timestamp->format('Y-m-d H:i:s'));
+        $this->assertSame(42, $result->userId);
+        $this->assertSame('127.0.0.1', $result->ipAddress);
+        $this->assertSame('PHPUnit', $result->userAgent);
+        $this->assertSame('user.login', $result->action);
+        $this->assertSame('auth', $result->entityType);
+        $this->assertSame('42', $result->entityId);
+        $this->assertSame(['key' => 'value'], $result->data);
+        $this->assertSame('abc123', $result->checksum);
+        $this->assertNull($result->dataError);
+    }
+
+    #[Test]
+    public function testMapHandlesNullUserId(): void
+    {
+        $row            = $this->validRow();
+        $row['user_id'] = null;
+
+        $result = ResultMapper::map($row, 'test context');
+
+        $this->assertNull($result->userId);
+    }
+
+    #[Test]
+    public function testMapCastsUserIdToInt(): void
+    {
+        $row            = $this->validRow();
+        $row['user_id'] = '42';
+
+        $result = ResultMapper::map($row, 'test context');
+
+        $this->assertSame(42, $result->userId);
+    }
+
+    #[Test]
+    public function testMapHandlesNullData(): void
+    {
+        $row         = $this->validRow();
+        $row['data'] = null;
+
+        $result = ResultMapper::map($row, 'test context');
+
+        $this->assertNull($result->data);
+    }
+
+    #[Test]
+    public function testMapHandlesMissingDataKey(): void
+    {
+        $row = $this->validRow();
+        unset($row['data']);
+
+        $result = ResultMapper::map($row, 'test context');
+
+        $this->assertNull($result->data);
+    }
+
+    #[Test]
+    public function testMapHandlesNonArrayData(): void
+    {
+        $row         = $this->validRow();
+        $row['data'] = 'not-an-array';
+
+        $result = ResultMapper::map($row, 'test context');
+
+        $this->assertNull($result->data);
+    }
+
+    #[Test]
+    public function testMapPassesDataError(): void
+    {
+        $result = ResultMapper::map($this->validRow(), 'test context', 'Corrupted JSON data');
+
+        $this->assertSame('Corrupted JSON data', $result->dataError);
+    }
+
+    #[Test]
+    public function testMapThrowsOnMissingRequiredFields(): void
+    {
+        $row = [
+            'id'        => 1,
+            'timestamp' => '2026-02-15 12:00:00',
+        ];
+
+        try {
+            ResultMapper::map($row, 'test context');
+            $this->fail('Expected StorageException was not thrown');
+        } catch (StorageException $storageException) {
+            $this->assertStringStartsWith('Missing required fields in test context: ', $storageException->getMessage());
+            $this->assertStringContainsString('user_id', $storageException->getMessage());
+            $this->assertStringContainsString('checksum', $storageException->getMessage());
+        }
+    }
+
+    /**
+     * Validates each required key is individually checked (kills ArrayItemRemoval mutants).
+     */
+    #[Test]
+    public function testMapDetectsEachMissingRequiredField(): void
+    {
+        $requiredKeys = ['id', 'timestamp', 'user_id', 'ip_address', 'user_agent', 'action', 'entity_type', 'entity_id', 'checksum'];
+
+        foreach ($requiredKeys as $key) {
+            $row = $this->validRow();
+            unset($row[$key]);
+
+            try {
+                ResultMapper::map($row, 'test context');
+                $this->fail(sprintf("Expected StorageException for missing '%s'", $key));
+            } catch (StorageException $storageException) {
+                $this->assertStringContainsString($key, $storageException->getMessage());
+            }
+        }
+    }
+
+    #[Test]
+    public function testMapThrowsOnInvalidTimestamp(): void
+    {
+        $row              = $this->validRow();
+        $row['timestamp'] = 'not-a-valid-date';
+
+        try {
+            ResultMapper::map($row, 'test context');
+            $this->fail('Expected StorageException was not thrown');
+        } catch (StorageException $storageException) {
+            $this->assertStringStartsWith('Invalid timestamp in test context: ', $storageException->getMessage());
+            $this->assertSame(0, $storageException->getCode());
+            $this->assertInstanceOf(DateMalformedStringException::class, $storageException->getPrevious());
+            $this->assertGreaterThan(
+                strlen('Invalid timestamp in test context: '),
+                strlen($storageException->getMessage()),
+            );
+        }
+    }
+
+    #[Test]
+    public function testMapUsesErrorContextInMessages(): void
+    {
+        $row              = $this->validRow();
+        $row['timestamp'] = 'invalid';
+
+        try {
+            ResultMapper::map($row, 'file log line 7');
+            $this->fail('Expected StorageException was not thrown');
+        } catch (StorageException $storageException) {
+            $this->assertStringContainsString('file log line 7', $storageException->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts duplicated schema validation, timestamp parsing, and `AuditLogResult` construction from `AuditLogger::mapRow()` and `FileLogReader::mapFileLogLine()` into a shared `ResultMapper` class
- Both callers now normalize their data and delegate to `ResultMapper::map()` with a context string for error messages
- Reduces ~80 lines of duplicated logic across the two mappers

Closes #9

## Test plan

- [x] All 162 existing tests pass (no regressions)
- [x] New `ResultMapperTest` with 11 tests covering schema validation, timestamp parsing, field casting, data handling, and error context
- [x] PHPStan, Psalm, Psalm taint analysis: no errors
- [x] Infection mutation testing: 275/275 killed, 100% MSI
- [x] CS-Fixer, Rector, PHPMD, Deptrac: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)