### PR TITLE
refactor: extract ChecksumCalculator and FileLogWriter from AuditLogger

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -34,10 +34,25 @@ deptrac:
         - type: classLike
           value: ^Zappzarapp\\AuditLogger\\AuditLoggerInterface$
 
+    - name: ResultMapper
+      collectors:
+        - type: classLike
+          value: ^Zappzarapp\\AuditLogger\\ResultMapper$
+
+    - name: ChecksumCalculator
+      collectors:
+        - type: classLike
+          value: ^Zappzarapp\\AuditLogger\\ChecksumCalculator$
+
     - name: FileLogReader
       collectors:
         - type: classLike
           value: ^Zappzarapp\\AuditLogger\\FileLogReader$
+
+    - name: FileLogWriter
+      collectors:
+        - type: classLike
+          value: ^Zappzarapp\\AuditLogger\\FileLogWriter$
 
     - name: CoreLogger
       collectors:
@@ -65,19 +80,39 @@ deptrac:
       - CoreDTO
       - Exception
 
-    # FileLogReader depends on Encryption, Exception, and CoreDTO
+    # ResultMapper depends on DTOs and Exception
+    ResultMapper:
+      - CoreDTO
+      - Exception
+
+    # ChecksumCalculator depends on DTOs and Exception
+    ChecksumCalculator:
+      - CoreDTO
+      - Exception
+
+    # FileLogReader depends on Encryption, Exception, CoreDTO, and ResultMapper
     FileLogReader:
       - Encryption
       - Exception
       - CoreDTO
+      - ResultMapper
 
-    # Logger depends on everything
+    # FileLogWriter depends on Encryption, Exception, and CoreDTO
+    FileLogWriter:
+      - Encryption
+      - Exception
+      - CoreDTO
+
+    # Logger depends on core components and extracted services
     CoreLogger:
       - CoreInterface
       - CoreDTO
       - Encryption
       - Exception
+      - ChecksumCalculator
+      - ResultMapper
       - FileLogReader
+      - FileLogWriter
 
     # NullLogger depends on Interface, DTOs, and Exception (transitively via Interface)
     CoreNullLogger:

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -75,8 +75,8 @@
     </rule>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects">
         <properties>
-            <!-- AuditLogger coordinates encryption, storage, DTOs, FileLogReader, and exceptions -->
-            <property name="maximum" value="16"/>
+            <!-- AuditLogger coordinates encryption, storage, DTOs, and extracted services (SRP refactoring) -->
+            <property name="maximum" value="19"/>
         </properties>
     </rule>
 

--- a/src/AuditLogger.php
+++ b/src/AuditLogger.php
@@ -29,21 +29,17 @@ final readonly class AuditLogger implements AuditLoggerInterface
 {
     private const string DB_HKDF_INFO = 'audit-logger-db-encryption';
 
-    private const string HMAC_HKDF_INFO = 'audit-logger-hmac';
-
-    private const string TIMESTAMP_FORMAT = 'Y-m-d H:i:s';
-
     private const int MAX_ENCODED_DATA_SIZE = 10_000;
 
     private bool $useDbEncryption;
 
-    private EncryptionInterface $fileEncryption;
+    private ChecksumCalculator $checksumCalculator;
+
+    private FileLogWriter $fileLogWriter;
 
     private FileLogReader $fileLogReader;
 
     private string $dbEncryptionKey;
-
-    private string $hmacKey;
 
     /**
      * @param PDO $pdo Database connection
@@ -61,7 +57,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
         private string $encryptionKey,
         private EncryptionInterface $encryption = new AppEncryption(),
         private string $tableName = 'audit_logs',
-        private ?string $logFilePath = null,
+        ?string $logFilePath = null,
         private ?int $maxLimit = null,
     ) {
         if (strlen($encryptionKey) < 32) {
@@ -74,13 +70,14 @@ final readonly class AuditLogger implements AuditLoggerInterface
 
         $this->validateIdentifier($tableName);
 
-        $this->useDbEncryption  = $encryption instanceof DatabaseEncryption;
-        $this->fileEncryption   = $this->useDbEncryption ? new AppEncryption() : $encryption;
-        $this->fileLogReader    = new FileLogReader($this->fileEncryption, $encryptionKey, $logFilePath);
-        $this->dbEncryptionKey  = $this->useDbEncryption
+        $this->useDbEncryption    = $encryption instanceof DatabaseEncryption;
+        $fileEncryption           = $this->useDbEncryption ? new AppEncryption() : $encryption;
+        $this->fileLogReader      = new FileLogReader($fileEncryption, $encryptionKey, $logFilePath);
+        $this->fileLogWriter      = new FileLogWriter($fileEncryption, $encryptionKey, $logFilePath);
+        $this->checksumCalculator = new ChecksumCalculator(ChecksumCalculator::deriveKey($encryptionKey));
+        $this->dbEncryptionKey    = $this->useDbEncryption
             ? hash_hkdf('sha256', $encryptionKey, 32, self::DB_HKDF_INFO)
             : '';
-        $this->hmacKey          = hash_hkdf('sha256', $encryptionKey, 32, self::HMAC_HKDF_INFO);
     }
 
     /**
@@ -88,8 +85,8 @@ final readonly class AuditLogger implements AuditLoggerInterface
      */
     public function log(AuditLogEntry $entry): void
     {
-        $timestamp = (new DateTimeImmutable())->format(self::TIMESTAMP_FORMAT);
-        $dataJson  = $this->encodeData($entry, $timestamp);
+        $timestamp = (new DateTimeImmutable())->format(ChecksumCalculator::TIMESTAMP_FORMAT);
+        $dataJson  = $this->checksumCalculator->encodeData($entry, $timestamp);
 
         if (strlen($dataJson) > self::MAX_ENCODED_DATA_SIZE) {
             throw new StorageException(
@@ -98,13 +95,13 @@ final readonly class AuditLogger implements AuditLoggerInterface
             );
         }
 
-        $checksum  = $this->calculateChecksum($timestamp, $entry, $dataJson);
+        $checksum = $this->checksumCalculator->calculate($timestamp, $entry, $dataJson);
 
         try {
             $this->writeToDatabase($timestamp, $entry, $dataJson, $checksum);
         } catch (PDOException $pdoException) {
             try {
-                $this->writeToFile($timestamp, $entry, $checksum);
+                $this->fileLogWriter->write($timestamp, $entry, $checksum);
             } catch (AuditLogException $fileException) {
                 throw new StorageException(
                     'Failed to write audit log to database AND file fallback: '
@@ -119,7 +116,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
         }
 
         try {
-            $this->writeToFile($timestamp, $entry, $checksum);
+            $this->fileLogWriter->write($timestamp, $entry, $checksum);
         } catch (AuditLogException) {
             // Silently ignore file write failures after successful database write.
             // The file log is a redundant fallback — the audit entry is already persisted.
@@ -210,34 +207,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
      */
     public function verify(AuditLogResult $result): bool
     {
-        try {
-            $dataJson = json_encode(
-                $this->buildEnvelope(
-                    $result->userAgent,
-                    $result->timestamp->format(self::TIMESTAMP_FORMAT),
-                    $result->data,
-                ),
-                JSON_THROW_ON_ERROR,
-            );
-        } catch (JsonException) {
-            return false;
-        }
-
-        $expected = hash_hmac(
-            'sha256',
-            $this->buildChecksumInput(
-                $result->timestamp->format(self::TIMESTAMP_FORMAT),
-                $result->userId,
-                $result->ipAddress,
-                $result->action,
-                $result->entityType,
-                $result->entityId,
-                $dataJson,
-            ),
-            $this->hmacKey,
-        );
-
-        return hash_equals($expected, $result->checksum);
+        return $this->checksumCalculator->verify($result);
     }
 
     /**
@@ -246,71 +216,6 @@ final readonly class AuditLogger implements AuditLoggerInterface
     public function readFileLog(): array
     {
         return $this->fileLogReader->readFileLog();
-    }
-
-    /**
-     * @param array<string, mixed>|null $data
-     * @return array{meta: array{user_agent: string, timestamp: string}, data: array<string, mixed>|null}
-     */
-    private function buildEnvelope(string $userAgent, string $timestamp, ?array $data): array
-    {
-        return [
-            'meta' => [
-                'user_agent' => $userAgent,
-                'timestamp'  => $timestamp,
-            ],
-            'data' => $data,
-        ];
-    }
-
-    /**
-     * @throws StorageException
-     */
-    private function encodeData(AuditLogEntry $entry, string $timestamp): string
-    {
-        try {
-            return json_encode(
-                $this->buildEnvelope($entry->userAgent, $timestamp, $entry->data),
-                JSON_THROW_ON_ERROR,
-            );
-        } catch (JsonException $jsonException) {
-            throw new StorageException('Failed to encode audit data as JSON: ' . $jsonException->getMessage(), 0, $jsonException);
-        }
-    }
-
-    private function calculateChecksum(string $timestamp, AuditLogEntry $entry, string $dataJson): string
-    {
-        return hash_hmac(
-            'sha256',
-            $this->buildChecksumInput(
-                $timestamp,
-                $entry->userId,
-                $entry->ipAddress,
-                $entry->action,
-                $entry->entityType,
-                (string) $entry->entityId,
-                $dataJson,
-            ),
-            $this->hmacKey,
-        );
-    }
-
-    private function buildChecksumInput(
-        string $timestamp,
-        ?int $userId,
-        string $ipAddress,
-        string $action,
-        string $entityType,
-        string $entityId,
-        string $dataJson,
-    ): string {
-        return $timestamp . "\0"
-            . ($userId ?? '') . "\0"
-            . $ipAddress . "\0"
-            . $action . "\0"
-            . $entityType . "\0"
-            . $entityId . "\0"
-            . $dataJson;
     }
 
     /**
@@ -358,54 +263,6 @@ final readonly class AuditLogger implements AuditLoggerInterface
         }
 
         $stmt->execute($params);
-    }
-
-    /**
-     * @throws EncryptionException
-     * @throws StorageException
-     */
-    private function writeToFile(string $timestamp, AuditLogEntry $entry, string $checksum): void
-    {
-        if ($this->logFilePath === null) {
-            return;
-        }
-
-        $logDir = dirname($this->logFilePath);
-        /** @infection-ignore-all: Permission value and mkdir failure path untestable without filesystem mocking */
-        if (!is_dir($logDir) && (!mkdir($logDir, 0700, true) && !is_dir($logDir))) {
-            throw new StorageException('Failed to create log directory: ' . $logDir);
-        }
-
-        try {
-            $logEntry = json_encode([
-                'timestamp'   => $timestamp,
-                'user_id'     => $entry->userId,
-                'ip_address'  => $entry->ipAddress,
-                'user_agent'  => $entry->userAgent,
-                'action'      => $entry->action,
-                'entity_type' => $entry->entityType,
-                'entity_id'   => (string) $entry->entityId,
-                'data'        => $entry->data,
-                'checksum'    => $checksum,
-            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        } catch (JsonException $jsonException) {
-            throw new StorageException('Failed to encode file log entry as JSON: ' . $jsonException->getMessage(), 0, $jsonException);
-        }
-
-        $encrypted = $this->fileEncryption->encrypt($logEntry, $this->encryptionKey);
-
-        /** @infection-ignore-all: Permission value and isNewFile check not meaningfully mutatable */
-        $isNewFile = !file_exists($this->logFilePath);
-
-        $result = file_put_contents($this->logFilePath, $encrypted . PHP_EOL, FILE_APPEND | LOCK_EX);
-
-        if ($result === false) {
-            throw new StorageException('Failed to write audit log to file: ' . $this->logFilePath);
-        }
-
-        if ($isNewFile) {
-            chmod($this->logFilePath, 0600);
-        }
     }
 
     /**

--- a/src/ChecksumCalculator.php
+++ b/src/ChecksumCalculator.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\AuditLogger;
+
+use JsonException;
+use Zappzarapp\AuditLogger\Exception\StorageException;
+
+/**
+ * Calculates and verifies HMAC-SHA256 checksums for audit log integrity
+ */
+final readonly class ChecksumCalculator
+{
+    public const string TIMESTAMP_FORMAT = 'Y-m-d H:i:s';
+
+    private const string HMAC_HKDF_INFO = 'audit-logger-hmac';
+
+    public function __construct(private string $hmacKey) {}
+
+    public static function deriveKey(string $encryptionKey): string
+    {
+        return hash_hkdf('sha256', $encryptionKey, 32, self::HMAC_HKDF_INFO);
+    }
+
+    /**
+     * Encode audit entry data as JSON envelope
+     *
+     * @throws StorageException
+     */
+    public function encodeData(AuditLogEntry $entry, string $timestamp): string
+    {
+        try {
+            return json_encode(
+                $this->buildEnvelope($entry->userAgent, $timestamp, $entry->data),
+                JSON_THROW_ON_ERROR,
+            );
+        } catch (JsonException $jsonException) {
+            throw new StorageException('Failed to encode audit data as JSON: ' . $jsonException->getMessage(), 0, $jsonException);
+        }
+    }
+
+    /**
+     * Calculate HMAC-SHA256 checksum for an audit log entry
+     */
+    public function calculate(string $timestamp, AuditLogEntry $entry, string $dataJson): string
+    {
+        return hash_hmac(
+            'sha256',
+            $this->buildChecksumInput(
+                $timestamp,
+                $entry->userId,
+                $entry->ipAddress,
+                $entry->action,
+                $entry->entityType,
+                (string) $entry->entityId,
+                $dataJson,
+            ),
+            $this->hmacKey,
+        );
+    }
+
+    /**
+     * Verify the integrity of an audit log result by recalculating its checksum
+     */
+    public function verify(AuditLogResult $result): bool
+    {
+        try {
+            $dataJson = json_encode(
+                $this->buildEnvelope(
+                    $result->userAgent,
+                    $result->timestamp->format(self::TIMESTAMP_FORMAT),
+                    $result->data,
+                ),
+                JSON_THROW_ON_ERROR,
+            );
+        } catch (JsonException) {
+            return false;
+        }
+
+        $expected = hash_hmac(
+            'sha256',
+            $this->buildChecksumInput(
+                $result->timestamp->format(self::TIMESTAMP_FORMAT),
+                $result->userId,
+                $result->ipAddress,
+                $result->action,
+                $result->entityType,
+                $result->entityId,
+                $dataJson,
+            ),
+            $this->hmacKey,
+        );
+
+        return hash_equals($expected, $result->checksum);
+    }
+
+    /**
+     * @param array<string, mixed>|null $data
+     * @return array{meta: array{user_agent: string, timestamp: string}, data: array<string, mixed>|null}
+     */
+    private function buildEnvelope(string $userAgent, string $timestamp, ?array $data): array
+    {
+        return [
+            'meta' => [
+                'user_agent' => $userAgent,
+                'timestamp'  => $timestamp,
+            ],
+            'data' => $data,
+        ];
+    }
+
+    private function buildChecksumInput(
+        string $timestamp,
+        ?int $userId,
+        string $ipAddress,
+        string $action,
+        string $entityType,
+        string $entityId,
+        string $dataJson,
+    ): string {
+        return $timestamp . "\0"
+            . ($userId ?? '') . "\0"
+            . $ipAddress . "\0"
+            . $action . "\0"
+            . $entityType . "\0"
+            . $entityId . "\0"
+            . $dataJson;
+    }
+}

--- a/src/FileLogWriter.php
+++ b/src/FileLogWriter.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\AuditLogger;
+
+use JsonException;
+use Zappzarapp\AuditLogger\Encryption\EncryptionInterface;
+use Zappzarapp\AuditLogger\Exception\EncryptionException;
+use Zappzarapp\AuditLogger\Exception\StorageException;
+
+/**
+ * Writes encrypted audit log entries to the file-based fallback log
+ */
+final readonly class FileLogWriter
+{
+    public function __construct(
+        private EncryptionInterface $fileEncryption,
+        private string $encryptionKey,
+        private ?string $logFilePath,
+    ) {}
+
+    /**
+     * Write an audit log entry to the file log
+     *
+     * @throws EncryptionException
+     * @throws StorageException
+     */
+    public function write(string $timestamp, AuditLogEntry $entry, string $checksum): void
+    {
+        if ($this->logFilePath === null) {
+            return;
+        }
+
+        $logDir = dirname($this->logFilePath);
+        /** @infection-ignore-all: Permission value and mkdir failure path untestable without filesystem mocking */
+        if (!is_dir($logDir) && (!mkdir($logDir, 0700, true) && !is_dir($logDir))) {
+            throw new StorageException('Failed to create log directory: ' . $logDir);
+        }
+
+        try {
+            $logEntry = json_encode([
+                'timestamp'   => $timestamp,
+                'user_id'     => $entry->userId,
+                'ip_address'  => $entry->ipAddress,
+                'user_agent'  => $entry->userAgent,
+                'action'      => $entry->action,
+                'entity_type' => $entry->entityType,
+                'entity_id'   => (string) $entry->entityId,
+                'data'        => $entry->data,
+                'checksum'    => $checksum,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        } catch (JsonException $jsonException) {
+            throw new StorageException('Failed to encode file log entry as JSON: ' . $jsonException->getMessage(), 0, $jsonException);
+        }
+
+        $encrypted = $this->fileEncryption->encrypt($logEntry, $this->encryptionKey);
+
+        /** @infection-ignore-all: Permission value and isNewFile check not meaningfully mutatable */
+        $isNewFile = !file_exists($this->logFilePath);
+
+        /** @infection-ignore-all: Concat swap ($encrypted . PHP_EOL vs PHP_EOL . $encrypted) — functionally equivalent after trim in FileLogReader */
+        $result = file_put_contents($this->logFilePath, $encrypted . PHP_EOL, FILE_APPEND | LOCK_EX);
+
+        if ($result === false) {
+            throw new StorageException('Failed to write audit log to file: ' . $this->logFilePath);
+        }
+
+        if ($isNewFile) {
+            chmod($this->logFilePath, 0600);
+        }
+    }
+}

--- a/tests/AuditLoggerWriteTest.php
+++ b/tests/AuditLoggerWriteTest.php
@@ -6,14 +6,12 @@ namespace Zappzarapp\AuditLogger\Tests;
 
 use InvalidArgumentException;
 use JsonException;
-use org\bovigo\vfs\vfsStream;
 use PDO;
 use PDOException;
 use PDOStatement;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 use Zappzarapp\AuditLogger\AuditLogEntry;
 use Zappzarapp\AuditLogger\AuditLogger;
 use Zappzarapp\AuditLogger\Encryption\AppEncryption;
@@ -916,46 +914,6 @@ final class AuditLoggerWriteTest extends TestCase
         $this->assertStringContainsString("\u{00E4}\u{00F6}\u{00FC}", $decrypted);
     }
 
-    /**
-     * Test writeToFile throws StorageException when JSON encoding of file log entry fails.
-     * Uses Reflection because encodeData() would fail first via log(), making this path unreachable.
-     *
-     * @noinspection PhpUnhandledExceptionInspection - ReflectionMethod on known private method
-     */
-    #[Test]
-    public function testWriteToFileThrowsStorageExceptionOnJsonEncodeFails(): void
-    {
-        $pdo = $this->createStub(PDO::class);
-
-        $logger = new AuditLogger(
-            pdo: $pdo,
-            encryptionKey: $this->encryptionKey,
-            encryption: new DatabaseEncryption(),
-            logFilePath: $this->tempLogFile,
-        );
-
-        $entry = new AuditLogEntry(
-            action: 'test.action',
-            entityType: 'test',
-            entityId: 1,
-            data: ['value' => NAN],
-        );
-
-        $method = new ReflectionMethod($logger, 'writeToFile');
-
-        try {
-            $method->invoke($logger, '2026-02-14 12:00:00', $entry, 'dummy-checksum');
-            $this->fail('Expected StorageException was not thrown');
-        } catch (StorageException $storageException) { // @phpstan-ignore catch.neverThrown (thrown inside Reflection invoke)
-            $this->assertStringStartsWith('Failed to encode file log entry as JSON: ', $storageException->getMessage());
-            $this->assertGreaterThan(
-                strlen('Failed to encode file log entry as JSON: '),
-                strlen($storageException->getMessage()),
-            );
-            $this->assertSame(0, $storageException->getCode());
-            $this->assertInstanceOf(JsonException::class, $storageException->getPrevious());
-        }
-    }
 
     #[Test]
     public function testLogThrowsStorageExceptionWhenDataExceedsMaxSize(): void
@@ -1106,74 +1064,4 @@ final class AuditLoggerWriteTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    #[Test]
-    public function testWriteToFileThrowsStorageExceptionOnMkdirFailure(): void
-    {
-        $root    = vfsStream::setup('root', 0000);
-        $logFile = $root->url() . '/subdir/audit.log';
-
-        $pdo = $this->createStub(PDO::class);
-
-        $logger = new AuditLogger(
-            pdo: $pdo,
-            encryptionKey: $this->encryptionKey,
-            encryption: new DatabaseEncryption(),
-            logFilePath: $logFile,
-        );
-
-        $entry  = new AuditLogEntry(
-            action: 'test.action',
-            entityType: 'test',
-            entityId: 1,
-        );
-
-        $method = new ReflectionMethod($logger, 'writeToFile');
-
-        try {
-            $method->invoke($logger, '2026-02-14 12:00:00', $entry, 'dummy-checksum');
-            $this->fail('Expected StorageException was not thrown');
-        } catch (StorageException $storageException) { // @phpstan-ignore catch.neverThrown (thrown inside Reflection invoke)
-            $this->assertStringStartsWith('Failed to create log directory: ', $storageException->getMessage());
-        }
-    }
-
-    #[Test]
-    public function testWriteToFileThrowsStorageExceptionOnWriteFailure(): void
-    {
-        $root = vfsStream::setup('root');
-        vfsStream::newDirectory('logs')->at($root);
-        $logFile = $root->url() . '/logs/audit.log';
-
-        // Quota 0 makes file_put_contents return false
-        vfsStream::setQuota(0);
-
-        $pdo = $this->createStub(PDO::class);
-
-        $logger = new AuditLogger(
-            pdo: $pdo,
-            encryptionKey: $this->encryptionKey,
-            encryption: new DatabaseEncryption(),
-            logFilePath: $logFile,
-        );
-
-        $entry  = new AuditLogEntry(
-            action: 'test.action',
-            entityType: 'test',
-            entityId: 1,
-        );
-
-        $method = new ReflectionMethod($logger, 'writeToFile');
-
-        // Suppress "Only 0 of N bytes written" PHP warning from file_put_contents
-        set_error_handler(static fn (): bool => true);
-        try {
-            $method->invoke($logger, '2026-02-14 12:00:00', $entry, 'dummy-checksum');
-            $this->fail('Expected StorageException was not thrown');
-        } catch (StorageException $storageException) { // @phpstan-ignore catch.neverThrown (thrown inside Reflection invoke)
-            $this->assertStringStartsWith('Failed to write audit log to file: ', $storageException->getMessage());
-            $this->assertStringContainsString($logFile, $storageException->getMessage());
-        } finally {
-            restore_error_handler();
-        }
-    }
 }

--- a/tests/ChecksumCalculatorTest.php
+++ b/tests/ChecksumCalculatorTest.php
@@ -1,0 +1,478 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\AuditLogger\Tests;
+
+use DateTimeImmutable;
+use JsonException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zappzarapp\AuditLogger\AuditLogEntry;
+use Zappzarapp\AuditLogger\AuditLogResult;
+use Zappzarapp\AuditLogger\ChecksumCalculator;
+use Zappzarapp\AuditLogger\Exception\StorageException;
+
+#[CoversClass(ChecksumCalculator::class)]
+final class ChecksumCalculatorTest extends TestCase
+{
+    private ChecksumCalculator $calculator;
+
+    private string $hmacKey;
+
+    protected function setUp(): void
+    {
+        $encryptionKey    = str_repeat('a', 32);
+        $this->hmacKey    = ChecksumCalculator::deriveKey($encryptionKey);
+        $this->calculator = new ChecksumCalculator($this->hmacKey);
+    }
+
+    #[Test]
+    public function testDeriveKeyProducesDeterministicOutput(): void
+    {
+        $key1 = ChecksumCalculator::deriveKey('a]32-byte-encryption-key-here!!');
+        $key2 = ChecksumCalculator::deriveKey('a]32-byte-encryption-key-here!!');
+
+        $this->assertSame($key1, $key2);
+    }
+
+    #[Test]
+    public function testEncodeDataReturnsJsonString(): void
+    {
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: '1',
+            userAgent: 'PHPUnit',
+            data: ['key' => 'value'],
+        );
+
+        $json    = $this->calculator->encodeData($entry, '2026-02-14 12:00:00');
+        $decoded = json_decode($json, true);
+
+        $this->assertIsArray($decoded);
+        $this->assertSame('PHPUnit', $decoded['meta']['user_agent']);
+        $this->assertSame('2026-02-14 12:00:00', $decoded['meta']['timestamp']);
+        $this->assertSame(['key' => 'value'], $decoded['data']);
+    }
+
+    #[Test]
+    public function testEncodeDataThrowsStorageExceptionOnJsonError(): void
+    {
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: '1',
+            data: ['value' => NAN],
+        );
+
+        try {
+            $this->calculator->encodeData($entry, '2026-02-14 12:00:00');
+            $this->fail('Expected StorageException was not thrown');
+        } catch (StorageException $storageException) {
+            $this->assertStringStartsWith('Failed to encode audit data as JSON: ', $storageException->getMessage());
+            $this->assertGreaterThan(
+                strlen('Failed to encode audit data as JSON: '),
+                strlen($storageException->getMessage()),
+            );
+            $this->assertSame(0, $storageException->getCode());
+            $this->assertInstanceOf(JsonException::class, $storageException->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function testCalculateReturnsHmacString(): void
+    {
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: '1',
+            userId: 42,
+            ipAddress: '127.0.0.1',
+        );
+
+        $dataJson = $this->calculator->encodeData($entry, '2026-02-14 12:00:00');
+        $checksum = $this->calculator->calculate('2026-02-14 12:00:00', $entry, $dataJson);
+
+        $this->assertSame(64, strlen($checksum));
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $checksum);
+    }
+
+    #[Test]
+    public function testCalculateIsDeterministic(): void
+    {
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: '1',
+        );
+
+        $dataJson  = $this->calculator->encodeData($entry, '2026-02-14 12:00:00');
+        $checksum1 = $this->calculator->calculate('2026-02-14 12:00:00', $entry, $dataJson);
+        $checksum2 = $this->calculator->calculate('2026-02-14 12:00:00', $entry, $dataJson);
+
+        $this->assertSame($checksum1, $checksum2);
+    }
+
+    #[Test]
+    public function testVerifyReturnsTrueForValidChecksum(): void
+    {
+        $entry     = new AuditLogEntry(
+            action: 'user.login',
+            entityType: 'auth',
+            entityId: '42',
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            data: ['key' => 'value'],
+        );
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = new AuditLogResult(
+            id: 1,
+            timestamp: new DateTimeImmutable($timestamp),
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            action: 'user.login',
+            entityType: 'auth',
+            entityId: '42',
+            data: ['key' => 'value'],
+            checksum: $checksum,
+        );
+
+        $this->assertTrue($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyReturnsFalseForTamperedData(): void
+    {
+        $entry     = new AuditLogEntry(
+            action: 'user.login',
+            entityType: 'auth',
+            entityId: '42',
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            data: ['key' => 'value'],
+        );
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = new AuditLogResult(
+            id: 1,
+            timestamp: new DateTimeImmutable($timestamp),
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            action: 'user.login',
+            entityType: 'auth',
+            entityId: '42',
+            data: ['key' => 'TAMPERED'],
+            checksum: $checksum,
+        );
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyWithEmptyData(): void
+    {
+        $entry     = new AuditLogEntry(
+            action: 'user.login',
+            entityType: 'auth',
+            entityId: '42',
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+        );
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = new AuditLogResult(
+            id: 1,
+            timestamp: new DateTimeImmutable($timestamp),
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            action: 'user.login',
+            entityType: 'auth',
+            entityId: '42',
+            data: [],
+            checksum: $checksum,
+        );
+
+        $this->assertTrue($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyWithNullUserId(): void
+    {
+        $entry     = new AuditLogEntry(
+            action: 'login.failed',
+            entityType: 'auth',
+            entityId: '0',
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+        );
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = new AuditLogResult(
+            id: 1,
+            timestamp: new DateTimeImmutable($timestamp),
+            userId: null,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            action: 'login.failed',
+            entityType: 'auth',
+            entityId: '0',
+            data: [],
+            checksum: $checksum,
+        );
+
+        $this->assertTrue($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyDetectsTamperedAction(): void
+    {
+        $entry     = $this->createTestEntry();
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = $this->createTestResult($timestamp, $checksum, action: 'TAMPERED');
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyDetectsTamperedEntityType(): void
+    {
+        $entry     = $this->createTestEntry();
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = $this->createTestResult($timestamp, $checksum, entityType: 'TAMPERED');
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyDetectsTamperedEntityId(): void
+    {
+        $entry     = $this->createTestEntry();
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = $this->createTestResult($timestamp, $checksum, entityId: '999');
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyDetectsTamperedIpAddress(): void
+    {
+        $entry     = $this->createTestEntry();
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = $this->createTestResult($timestamp, $checksum, ipAddress: '10.0.0.1');
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyDetectsTamperedUserAgent(): void
+    {
+        $entry     = $this->createTestEntry();
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = $this->createTestResult($timestamp, $checksum, userAgent: 'TAMPERED');
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyDetectsTamperedTimestamp(): void
+    {
+        $entry     = $this->createTestEntry();
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = $this->createTestResult('2026-02-14 13:00:00', $checksum);
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyDetectsTamperedUserId(): void
+    {
+        $entry     = $this->createTestEntry();
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = $this->createTestResult($timestamp, $checksum, userId: 999);
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyDetectsNullUserIdTamperedToNonNull(): void
+    {
+        $entry     = new AuditLogEntry(
+            action: 'login.failed',
+            entityType: 'auth',
+            entityId: '0',
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+        );
+        $timestamp = '2026-02-14 12:00:00';
+        $dataJson  = $this->calculator->encodeData($entry, $timestamp);
+        $checksum  = $this->calculator->calculate($timestamp, $entry, $dataJson);
+
+        $result = new AuditLogResult(
+            id: 1,
+            timestamp: new DateTimeImmutable($timestamp),
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            action: 'login.failed',
+            entityType: 'auth',
+            entityId: '0',
+            data: [],
+            checksum: $checksum,
+        );
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testVerifyDetectsTamperedChecksum(): void
+    {
+        $this->createTestEntry();
+        $timestamp = '2026-02-14 12:00:00';
+
+        $result = $this->createTestResult($timestamp, 'invalid-checksum');
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
+    public function testEncodeDataWithNullData(): void
+    {
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: '1',
+            data: [],
+        );
+
+        $json    = $this->calculator->encodeData($entry, '2026-02-14 12:00:00');
+        $decoded = json_decode($json, true);
+
+        $this->assertSame([], $decoded['data']);
+    }
+
+    /**
+     * Golden-value test: verifies the exact checksum for a known input.
+     * Kills all ConcatOperandRemoval/Concat mutants in buildChecksumInput(),
+     * since any structural change to the concatenation produces a different HMAC.
+     */
+    #[Test]
+    public function testCalculateProducesExpectedGoldenChecksum(): void
+    {
+        // Use a fixed key to produce a deterministic checksum
+        $hmacKey    = hash_hkdf('sha256', str_repeat('k', 32), 32, 'audit-logger-hmac');
+        $calculator = new ChecksumCalculator($hmacKey);
+
+        $entry     = new AuditLogEntry(
+            action: 'user.login',
+            entityType: 'auth',
+            entityId: '42',
+            userId: 7,
+            ipAddress: '10.0.0.1',
+            userAgent: 'TestAgent',
+            data: ['role' => 'admin'],
+        );
+        $timestamp = '2026-01-01 00:00:00';
+        $dataJson  = $calculator->encodeData($entry, $timestamp);
+
+        // Pre-computed golden value — any mutation to buildChecksumInput changes this
+        $expected = hash_hmac(
+            'sha256',
+            "2026-01-01 00:00:00\x007\x0010.0.0.1\x00user.login\x00auth\x0042\x00" . $dataJson,
+            $hmacKey,
+        );
+
+        $this->assertSame($expected, $calculator->calculate($timestamp, $entry, $dataJson));
+    }
+
+    /**
+     * Kills DecrementInteger/IncrementInteger mutants on deriveKey() key length parameter.
+     */
+    #[Test]
+    public function testDeriveKeyProduces32ByteKey(): void
+    {
+        $key = ChecksumCalculator::deriveKey(str_repeat('a', 32));
+
+        $this->assertSame(32, strlen($key));
+    }
+
+    #[Test]
+    public function testTimestampFormatConstant(): void
+    {
+        $this->assertSame('Y-m-d H:i:s', ChecksumCalculator::TIMESTAMP_FORMAT);
+    }
+
+    private function createTestEntry(): AuditLogEntry
+    {
+        return new AuditLogEntry(
+            action: 'user.login',
+            entityType: 'auth',
+            entityId: '42',
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            data: ['key' => 'value'],
+        );
+    }
+
+    private function createTestResult(
+        string $timestamp,
+        string $checksum,
+        ?int $userId = 42,
+        string $ipAddress = '127.0.0.1',
+        string $userAgent = 'PHPUnit',
+        string $action = 'user.login',
+        string $entityType = 'auth',
+        string $entityId = '42',
+    ): AuditLogResult {
+        return new AuditLogResult(
+            id: 1,
+            timestamp: new DateTimeImmutable($timestamp),
+            userId: $userId,
+            ipAddress: $ipAddress,
+            userAgent: $userAgent,
+            action: $action,
+            entityType: $entityType,
+            entityId: $entityId,
+            data: ['key' => 'value'],
+            checksum: $checksum,
+        );
+    }
+}

--- a/tests/FileLogWriterTest.php
+++ b/tests/FileLogWriterTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\AuditLogger\Tests;
+
+use JsonException;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zappzarapp\AuditLogger\AuditLogEntry;
+use Zappzarapp\AuditLogger\Encryption\AppEncryption;
+use Zappzarapp\AuditLogger\Exception\StorageException;
+use Zappzarapp\AuditLogger\FileLogWriter;
+
+#[CoversClass(FileLogWriter::class)]
+final class FileLogWriterTest extends TestCase
+{
+    private string $encryptionKey;
+
+    private string $tempLogFile;
+
+    protected function setUp(): void
+    {
+        $this->encryptionKey = str_repeat('a', 32);
+        $this->tempLogFile   = sys_get_temp_dir() . '/audit-file-write-test-' . uniqid() . '.log';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->tempLogFile)) {
+            unlink($this->tempLogFile);
+        }
+    }
+
+    #[Test]
+    public function testWriteCreatesEncryptedLogEntryWithAllFields(): void
+    {
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            data: ['key' => 'value'],
+        );
+
+        $writer->write('2026-02-14 12:00:00', $entry, 'dummy-checksum');
+
+        $this->assertFileExists($this->tempLogFile);
+        $content   = file_get_contents($this->tempLogFile);
+        $this->assertNotFalse($content);
+        $decrypted = (new AppEncryption())->decrypt(trim($content), $this->encryptionKey);
+        $decoded   = json_decode($decrypted, true);
+        $this->assertSame('2026-02-14 12:00:00', $decoded['timestamp']);
+        $this->assertSame(42, $decoded['user_id']);
+        $this->assertSame('127.0.0.1', $decoded['ip_address']);
+        $this->assertSame('PHPUnit', $decoded['user_agent']);
+        $this->assertSame('test.action', $decoded['action']);
+        $this->assertSame('test', $decoded['entity_type']);
+        $this->assertSame('1', $decoded['entity_id']);
+        $this->assertSame(['key' => 'value'], $decoded['data']);
+        $this->assertSame('dummy-checksum', $decoded['checksum']);
+    }
+
+    #[Test]
+    public function testWriteDoesNothingWhenLogFilePathIsNull(): void
+    {
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: null,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+        );
+
+        $writer->write('2026-02-14 12:00:00', $entry, 'checksum');
+
+        $this->assertFileDoesNotExist($this->tempLogFile);
+    }
+
+    /**
+     * Test write throws StorageException when JSON encoding fails (e.g. NAN values).
+     */
+    #[Test]
+    public function testWriteThrowsStorageExceptionOnJsonEncodeFails(): void
+    {
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+            data: ['value' => NAN],
+        );
+
+        try {
+            $writer->write('2026-02-14 12:00:00', $entry, 'dummy-checksum');
+            $this->fail('Expected StorageException was not thrown');
+        } catch (StorageException $storageException) {
+            $this->assertStringStartsWith('Failed to encode file log entry as JSON: ', $storageException->getMessage());
+            $this->assertGreaterThan(
+                strlen('Failed to encode file log entry as JSON: '),
+                strlen($storageException->getMessage()),
+            );
+            $this->assertSame(0, $storageException->getCode());
+            $this->assertInstanceOf(JsonException::class, $storageException->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function testWriteThrowsStorageExceptionOnMkdirFailure(): void
+    {
+        $root    = vfsStream::setup('root', 0000);
+        $logFile = $root->url() . '/subdir/audit.log';
+
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $logFile,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+        );
+
+        try {
+            $writer->write('2026-02-14 12:00:00', $entry, 'dummy-checksum');
+            $this->fail('Expected StorageException was not thrown');
+        } catch (StorageException $storageException) {
+            $this->assertStringStartsWith('Failed to create log directory: ', $storageException->getMessage());
+        }
+    }
+
+    #[Test]
+    public function testWriteThrowsStorageExceptionOnWriteFailure(): void
+    {
+        $root = vfsStream::setup('root');
+        vfsStream::newDirectory('logs')->at($root);
+        $logFile = $root->url() . '/logs/audit.log';
+
+        // Quota 0 makes file_put_contents return false
+        vfsStream::setQuota(0);
+
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $logFile,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+        );
+
+        // Suppress "Only 0 of N bytes written" PHP warning from file_put_contents
+        set_error_handler(static fn (): bool => true);
+        try {
+            $writer->write('2026-02-14 12:00:00', $entry, 'dummy-checksum');
+            $this->fail('Expected StorageException was not thrown');
+        } catch (StorageException $storageException) {
+            $this->assertStringStartsWith('Failed to write audit log to file: ', $storageException->getMessage());
+            $this->assertStringContainsString($logFile, $storageException->getMessage());
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    #[Test]
+    public function testWritePreservesSlashesAndUnicode(): void
+    {
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+            data: ['url' => '/api/v1/users', 'name' => "\u{00E4}\u{00F6}\u{00FC}"],
+        );
+
+        $writer->write('2026-02-14 12:00:00', $entry, 'checksum');
+
+        $content   = file_get_contents($this->tempLogFile);
+        $this->assertNotFalse($content);
+        $decrypted = (new AppEncryption())->decrypt(trim($content), $this->encryptionKey);
+
+        $this->assertStringContainsString('/api/v1/users', $decrypted);
+        $this->assertStringContainsString("\u{00E4}\u{00F6}\u{00FC}", $decrypted);
+    }
+
+    #[Test]
+    public function testWriteAppendsMultipleEntries(): void
+    {
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        $entry1 = new AuditLogEntry(action: 'first', entityType: 'test', entityId: 1);
+        $entry2 = new AuditLogEntry(action: 'second', entityType: 'test', entityId: 2);
+
+        $writer->write('2026-02-14 12:00:00', $entry1, 'checksum1');
+        $writer->write('2026-02-14 12:01:00', $entry2, 'checksum2');
+
+        $content = file_get_contents($this->tempLogFile);
+        $this->assertNotFalse($content);
+        $lines   = explode(PHP_EOL, trim($content));
+        $this->assertCount(2, $lines);
+
+        $encryption = new AppEncryption();
+        $decoded1   = json_decode($encryption->decrypt($lines[0], $this->encryptionKey), true);
+        $decoded2   = json_decode($encryption->decrypt($lines[1], $this->encryptionKey), true);
+        $this->assertSame('first', $decoded1['action']);
+        $this->assertSame('second', $decoded2['action']);
+    }
+
+    #[Test]
+    public function testNewLogFileHasRestrictedPermissions(): void
+    {
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+        );
+
+        $writer->write('2026-02-14 12:00:00', $entry, 'checksum');
+
+        $this->assertFileExists($this->tempLogFile);
+        $this->assertSame(0600, fileperms($this->tempLogFile) & 0777);
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts HMAC checksum logic (calculate, verify, data envelope) into `ChecksumCalculator`
- Extracts file fallback writing into `FileLogWriter` (complements existing `FileLogReader`)
- Reduces `AuditLogger` from ~526 to ~383 lines (-27%)
- Adds deptrac layers for all extracted services (`ChecksumCalculator`, `FileLogWriter`, `ResultMapper`)
- Deptrac: 0 violations, 0 uncovered (was 2 uncovered)

Closes #8

## Test plan

- [x] 191 tests, 552 assertions (29 new tests for extracted classes)
- [x] PHPStan, Psalm, Psalm taint analysis: no errors
- [x] Infection: 273/273 killed, 100% MSI
- [x] CS-Fixer, Rector, PHPMD, Deptrac: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)