### PR TITLE
feat: add file size limits to FileLogReader and FileLogWriter

### DIFF
--- a/src/FileLogReader.php
+++ b/src/FileLogReader.php
@@ -16,6 +16,8 @@ use Zappzarapp\AuditLogger\Exception\StorageException;
  */
 final readonly class FileLogReader
 {
+    private const int MAX_FILE_LOG_SIZE = 10_485_760;
+
     public function __construct(
         private EncryptionInterface $fileEncryption,
         private string $encryptionKey,
@@ -34,6 +36,13 @@ final readonly class FileLogReader
     {
         if ($this->logFilePath === null || !file_exists($this->logFilePath)) {
             return [];
+        }
+
+        $fileSize = filesize($this->logFilePath);
+        if ($fileSize === false || $fileSize > self::MAX_FILE_LOG_SIZE) {
+            throw new StorageException(
+                'File log exceeds maximum size of ' . self::MAX_FILE_LOG_SIZE . ' bytes',
+            );
         }
 
         $content = file_get_contents($this->logFilePath);

--- a/src/FileLogWriter.php
+++ b/src/FileLogWriter.php
@@ -14,6 +14,8 @@ use Zappzarapp\AuditLogger\Exception\StorageException;
  */
 final readonly class FileLogWriter
 {
+    private const int MAX_FILE_LOG_SIZE = 10_485_760;
+
     public function __construct(
         private EncryptionInterface $fileEncryption,
         private string $encryptionKey,
@@ -31,6 +33,8 @@ final readonly class FileLogWriter
         if ($this->logFilePath === null) {
             return;
         }
+
+        $this->guardFileSize($this->logFilePath);
 
         $logDir = dirname($this->logFilePath);
         /** @infection-ignore-all: Permission value and mkdir failure path untestable without filesystem mocking */
@@ -68,6 +72,23 @@ final readonly class FileLogWriter
 
         if ($isNewFile) {
             chmod($this->logFilePath, 0600);
+        }
+    }
+
+    /**
+     * @throws StorageException
+     */
+    private function guardFileSize(string $filePath): void
+    {
+        if (!file_exists($filePath)) {
+            return;
+        }
+
+        $fileSize = filesize($filePath);
+        if ($fileSize !== false && $fileSize > self::MAX_FILE_LOG_SIZE) {
+            throw new StorageException(
+                'File log exceeds maximum size of ' . self::MAX_FILE_LOG_SIZE . ' bytes',
+            );
         }
     }
 }

--- a/tests/FileLogReaderTest.php
+++ b/tests/FileLogReaderTest.php
@@ -385,4 +385,46 @@ final class FileLogReaderTest extends TestCase
         $decrypted     = $appEncryption->decrypt(trim($content), $this->encryptionKey);
         $this->assertJson($decrypted);
     }
+
+    #[Test]
+    public function testReadFileLogThrowsStorageExceptionWhenFileTooLarge(): void
+    {
+        // Create a file exceeding 10 MB
+        file_put_contents($this->tempLogFile, str_repeat('x', 10_485_761));
+
+        $reader = new FileLogReader(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        $this->expectException(StorageException::class);
+        $this->expectExceptionMessage('File log exceeds maximum size of 10485760 bytes');
+
+        $reader->readFileLog();
+    }
+
+    /**
+     * Boundary test: file at exactly MAX_FILE_LOG_SIZE must be accepted (kills > to >= mutant).
+     */
+    #[Test]
+    public function testReadFileLogAcceptsFileAtExactMaxSize(): void
+    {
+        // Create file at exactly 10 MB
+        file_put_contents($this->tempLogFile, str_repeat('x', 10_485_760));
+
+        $reader = new FileLogReader(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        // Size check passes — decryption will fail on garbage data, but that's expected
+        try {
+            $reader->readFileLog();
+        } catch (StorageException | EncryptionException $exception) {
+            // Must NOT be the size-limit error
+            $this->assertStringNotContainsString('exceeds maximum size', $exception->getMessage());
+        }
+    }
 }

--- a/tests/FileLogWriterTest.php
+++ b/tests/FileLogWriterTest.php
@@ -258,4 +258,74 @@ final class FileLogWriterTest extends TestCase
         $this->assertFileExists($this->tempLogFile);
         $this->assertSame(0600, fileperms($this->tempLogFile) & 0777);
     }
+
+    #[Test]
+    public function testWriteThrowsStorageExceptionWhenFileTooLarge(): void
+    {
+        // Create a file exceeding 10 MB
+        file_put_contents($this->tempLogFile, str_repeat('x', 10_485_761));
+
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+        );
+
+        $this->expectException(StorageException::class);
+        $this->expectExceptionMessage('File log exceeds maximum size of 10485760 bytes');
+
+        $writer->write('2026-02-14 12:00:00', $entry, 'checksum');
+    }
+
+    #[Test]
+    public function testWriteAcceptsFileAtExactMaxSize(): void
+    {
+        // Create a file at exactly 10 MB
+        file_put_contents($this->tempLogFile, str_repeat('x', 10_485_760));
+
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+        );
+
+        // Should not throw on size check — file is exactly at the limit
+        $writer->write('2026-02-14 12:00:00', $entry, 'checksum');
+
+        // File was written to (grew beyond 10 MB)
+        $this->assertGreaterThan(10_485_760, filesize($this->tempLogFile));
+    }
+
+    #[Test]
+    public function testWriteAllowsNewFileCreation(): void
+    {
+        $writer = new FileLogWriter(
+            fileEncryption: new AppEncryption(),
+            encryptionKey: $this->encryptionKey,
+            logFilePath: $this->tempLogFile,
+        );
+
+        $entry = new AuditLogEntry(
+            action: 'test.action',
+            entityType: 'test',
+            entityId: 1,
+        );
+
+        // File doesn't exist yet — should succeed
+        $this->assertFileDoesNotExist($this->tempLogFile);
+        $writer->write('2026-02-14 12:00:00', $entry, 'checksum');
+        $this->assertFileExists($this->tempLogFile);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds 10 MB (`MAX_FILE_LOG_SIZE`) size guard to `FileLogReader` before `file_get_contents` to prevent memory exhaustion
- Adds matching size guard to `FileLogWriter` before `file_put_contents` to prevent unbounded file growth
- Both throw `StorageException` when the limit is exceeded

Closes #3
Closes #6

## Test plan

- [x] 196 tests, 560 assertions (5 new boundary/limit tests)
- [x] Infection: 300/300 killed, 100% MSI
- [x] All static analysis, CS, PHPMD, Deptrac: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)