### PR TITLE
feat: add schema type validation for id and user_id fields

### DIFF
--- a/src/ResultMapper.php
+++ b/src/ResultMapper.php
@@ -39,6 +39,7 @@ final class ResultMapper
     public static function map(array $row, string $errorContext, ?string $dataError = null): AuditLogResult
     {
         self::validateSchema($row, $errorContext);
+        self::validateTypes($row, $errorContext);
 
         return new AuditLogResult(
             id: (int) $row['id'],
@@ -66,6 +67,22 @@ final class ResultMapper
         $missingKeys = array_diff(self::REQUIRED_KEYS, array_keys($row));
         if ($missingKeys !== []) {
             throw new StorageException('Missing required fields in ' . $errorContext . ': ' . implode(', ', $missingKeys));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @throws StorageException
+     */
+    private static function validateTypes(array $row, string $errorContext): void
+    {
+        if (!is_numeric($row['id'])) {
+            throw new StorageException('Invalid type for id in ' . $errorContext . ': expected numeric');
+        }
+
+        if ($row['user_id'] !== null && !is_numeric($row['user_id'])) {
+            throw new StorageException('Invalid type for user_id in ' . $errorContext . ': expected numeric or null');
         }
     }
 

--- a/tests/ResultMapperTest.php
+++ b/tests/ResultMapperTest.php
@@ -188,4 +188,50 @@ final class ResultMapperTest extends TestCase
             $this->assertStringContainsString('file log line 7', $storageException->getMessage());
         }
     }
+
+    #[Test]
+    public function testMapThrowsOnNonNumericId(): void
+    {
+        $row       = $this->validRow();
+        $row['id'] = 'not-a-number';
+
+        $this->expectException(StorageException::class);
+        $this->expectExceptionMessage('Invalid type for id in test context: expected numeric');
+
+        ResultMapper::map($row, 'test context');
+    }
+
+    #[Test]
+    public function testMapThrowsOnNonNumericUserId(): void
+    {
+        $row            = $this->validRow();
+        $row['user_id'] = 'not-a-number';
+
+        $this->expectException(StorageException::class);
+        $this->expectExceptionMessage('Invalid type for user_id in test context: expected numeric or null');
+
+        ResultMapper::map($row, 'test context');
+    }
+
+    #[Test]
+    public function testMapAcceptsStringNumericId(): void
+    {
+        $row       = $this->validRow();
+        $row['id'] = '42';
+
+        $result = ResultMapper::map($row, 'test context');
+
+        $this->assertSame(42, $result->id);
+    }
+
+    #[Test]
+    public function testMapAcceptsStringNumericUserId(): void
+    {
+        $row            = $this->validRow();
+        $row['user_id'] = '42';
+
+        $result = ResultMapper::map($row, 'test context');
+
+        $this->assertSame(42, $result->userId);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `validateTypes()` to `ResultMapper` checking `id` (numeric) and `user_id` (numeric or null)
- Catches corrupted database entries early instead of silently casting invalid values to 0
- Timestamp validation was already covered by `parseTimestamp()`

Closes #7

## Test plan

- [x] 200 tests, 566 assertions (4 new type validation tests)
- [x] Infection: 319/319 killed, 100% MSI
- [x] All checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)