### PR TITLE
refactor: Node.js parity for verify() and logAdmin()

### DIFF
--- a/src/AuditLogger.php
+++ b/src/AuditLogger.php
@@ -156,7 +156,6 @@ final readonly class AuditLogger implements AuditLoggerInterface
         string $ipAddress = 'unknown',
         string $userAgent = 'unknown',
     ): void {
-        $data['admin_user_id'] = $adminUserId;
         $this->log(new AuditLogEntry(
             action: $action,
             entityType: $entityType,
@@ -164,7 +163,7 @@ final readonly class AuditLogger implements AuditLoggerInterface
             userId: $adminUserId,
             ipAddress: $ipAddress,
             userAgent: $userAgent,
-            data: $data,
+            data: [...$data, 'admin_user_id' => $adminUserId],
         ));
     }
 

--- a/src/ChecksumCalculator.php
+++ b/src/ChecksumCalculator.php
@@ -66,6 +66,7 @@ final readonly class ChecksumCalculator
     public function verify(AuditLogResult $result): bool
     {
         if ($result->dataError !== null) {
+            /** @infection-ignore-all: ReturnRemoval — removing return still yields false (HMAC mismatch), early-return is an optimisation */
             return false;
         }
 

--- a/src/ChecksumCalculator.php
+++ b/src/ChecksumCalculator.php
@@ -65,6 +65,10 @@ final readonly class ChecksumCalculator
      */
     public function verify(AuditLogResult $result): bool
     {
+        if ($result->dataError !== null) {
+            return false;
+        }
+
         try {
             $dataJson = json_encode(
                 $this->buildEnvelope(

--- a/tests/AuditLoggerVerifyTest.php
+++ b/tests/AuditLoggerVerifyTest.php
@@ -398,6 +398,32 @@ final class AuditLoggerVerifyTest extends TestCase
     }
 
     #[Test]
+    public function testVerifyReturnsFalseWhenDataErrorIsSet(): void
+    {
+        $pdo    = $this->createStub(PDO::class);
+        $logger = new AuditLogger(
+            pdo: $pdo,
+            encryptionKey: $this->encryptionKey,
+        );
+
+        $result = new AuditLogResult(
+            id: 1,
+            timestamp: new DateTimeImmutable(),
+            userId: 1,
+            ipAddress: '127.0.0.1',
+            userAgent: 'unknown',
+            action: 'test',
+            entityType: 'test',
+            entityId: '1',
+            data: null,
+            checksum: 'abc',
+            dataError: 'Corrupted JSON data: Syntax error',
+        );
+
+        $this->assertFalse($logger->verify($result));
+    }
+
+    #[Test]
     public function testVerifyReturnsFalseWhenJsonEncodeFails(): void
     {
         $pdo    = $this->createStub(PDO::class);

--- a/tests/AuditLoggerWriteTest.php
+++ b/tests/AuditLoggerWriteTest.php
@@ -364,7 +364,8 @@ final class AuditLoggerWriteTest extends TestCase
                 $decoded  = json_decode($dataJson, true);
                 return is_array($decoded)
                     && is_array($decoded['data'] ?? null)
-                    && ($decoded['data']['admin_user_id'] ?? null) === 99;
+                    && ($decoded['data']['admin_user_id'] ?? null) === 99
+                    && ($decoded['data']['reason'] ?? null) === 'violation';
             }))
             ->willReturn(true);
 

--- a/tests/ChecksumCalculatorTest.php
+++ b/tests/ChecksumCalculatorTest.php
@@ -362,6 +362,26 @@ final class ChecksumCalculatorTest extends TestCase
     }
 
     #[Test]
+    public function testVerifyReturnsFalseWhenDataErrorIsSet(): void
+    {
+        $result = new AuditLogResult(
+            id: 1,
+            timestamp: new DateTimeImmutable('2026-02-14 12:00:00'),
+            userId: 42,
+            ipAddress: '127.0.0.1',
+            userAgent: 'PHPUnit',
+            action: 'user.login',
+            entityType: 'auth',
+            entityId: '42',
+            data: null,
+            checksum: 'abc',
+            dataError: 'Corrupted JSON data: Syntax error',
+        );
+
+        $this->assertFalse($this->calculator->verify($result));
+    }
+
+    #[Test]
     public function testVerifyDetectsTamperedChecksum(): void
     {
         $this->createTestEntry();


### PR DESCRIPTION
## Summary
- Add `dataError` early-return in `verify()` — skips unnecessary HMAC computation when data is already known to be corrupt (#1)
- Use array spread in `logAdmin()` instead of mutating the input array (#2)

Both changes align the PHP implementation with the Node.js audit logger.

## Test plan
- [x] New test `testVerifyReturnsFalseWhenDataErrorIsSet` in `ChecksumCalculatorTest`
- [x] New test `testVerifyReturnsFalseWhenDataErrorIsSet` in `AuditLoggerVerifyTest`
- [x] All 202 tests pass
- [x] All static analysis checks pass (PHPStan, Psalm, PHPMD, Rector, Deptrac)

Closes #1, closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)