### PR TITLE
docs: document DB query timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ $auditLogger = new NullAuditLogger();
 > }
 > ```
 
+> **Note:** The library does not set query timeouts on the injected PDO connection.
+> Configure timeouts at the connection level to prevent indefinite blocking:
+>
+> ```php
+> // PostgreSQL
+> $pdo->exec('SET statement_timeout = 5000'); // 5 seconds
+>
+> // MariaDB / MySQL
+> $pdo = new PDO($dsn, $user, $pass, [
+>     PDO::ATTR_TIMEOUT => 5,
+> ]);
+> ```
+
 ## Database Setup
 
 Apply the migration for your database:


### PR DESCRIPTION
## Summary
- Document that DB query timeouts should be configured on the injected PDO connection, not by the library
- Add examples for PostgreSQL (`SET statement_timeout`) and MariaDB/MySQL (`PDO::ATTR_TIMEOUT`)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)