### PR TITLE
ci: align GPG verification and release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,30 +53,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Verify GPG signatures
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            unsigned=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/commits \
-              --paginate --jq '[.[] | select(.commit.verification.verified != true)] | length')
-            if [ "$unsigned" -gt 0 ]; then
-              echo "::error::Found $unsigned unsigned commit(s) in PR. All commits must be GPG-signed."
-              gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/commits \
-                --paginate --jq '.[] | select(.commit.verification.verified != true) | "  \(.sha[0:7]) — \(.commit.message | split("\n")[0])"'
-              exit 1
-            fi
-            echo "All PR commits are GPG-signed."
-          else
-            verified=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }} \
-              --jq '.commit.verification.verified')
-            if [ "$verified" != "true" ]; then
-              echo "::error::Commit ${{ github.sha }} is not GPG-signed."
-              exit 1
-            fi
-            echo "Commit is GPG-signed."
-          fi
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,18 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Run release-please
         uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -30,5 +38,5 @@ jobs:
       - name: Upload SBOM to release
         if: ${{ steps.release.outputs.release_created }}
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ steps.release.outputs.tag_name }} sbom.json
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh release upload ${{ steps.release.outputs.tag_name }} sbom.json --clobber

--- a/.github/workflows/verify-signatures.yml
+++ b/.github/workflows/verify-signatures.yml
@@ -1,0 +1,89 @@
+name: Verify Signatures
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify GPG Signatures
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify all commits are signed (via GitHub API)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Checking commits in this PR/push via GitHub API..."
+
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # For push events, check commits
+            HEAD_SHA="${{ github.sha }}"
+            BEFORE_SHA="${{ github.event.before }}"
+
+            # Handle new branches where github.event.before is null SHA
+            if [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+              echo "New branch detected, checking all commits since master..."
+              BASE_SHA=$(git merge-base origin/master ${HEAD_SHA} 2>/dev/null || echo "")
+              if [ -z "$BASE_SHA" ]; then
+                echo "No common ancestor with master, checking only HEAD commit"
+                BASE_SHA="${HEAD_SHA}^"
+              fi
+            else
+              BASE_SHA="${BEFORE_SHA}"
+            fi
+          fi
+
+          COMMITS=$(git rev-list ${BASE_SHA}..${HEAD_SHA} 2>/dev/null || echo "${HEAD_SHA}")
+          UNSIGNED_COMMITS=()
+
+          for commit in $COMMITS; do
+            # Use GitHub API to check signature verification
+            VERIFIED=$(gh api repos/${{ github.repository }}/commits/${commit} --jq '.commit.verification.verified')
+            if [ "$VERIFIED" != "true" ]; then
+              UNSIGNED_COMMITS+=("$commit")
+              REASON=$(gh api repos/${{ github.repository }}/commits/${commit} --jq '.commit.verification.reason')
+              echo "❌ Commit $commit is NOT verified (reason: $REASON)"
+            else
+              echo "✅ Commit $commit is verified"
+            fi
+          done
+
+          if [ ${#UNSIGNED_COMMITS[@]} -gt 0 ]; then
+            echo ""
+            echo "ERROR: Found ${#UNSIGNED_COMMITS[@]} unverified commit(s)!"
+            echo ""
+            echo "All commits must be GPG-signed for security packages."
+            echo "See CONTRIBUTING.md for setup instructions."
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ All commits are verified!"
+
+      - name: Verify tag signature (if tagged)
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          # Use GitHub API to check tag verification
+          VERIFIED=$(gh api repos/${{ github.repository }}/git/tags/$(gh api repos/${{ github.repository }}/git/ref/tags/${TAG} --jq '.object.sha') --jq '.verification.verified' 2>/dev/null || echo "false")
+          if [ "$VERIFIED" != "true" ]; then
+            echo "❌ Tag $TAG is NOT verified"
+            echo "Create signed tags with: git tag -s"
+            exit 1
+          fi
+          echo "✅ Tag $TAG is verified"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,21 @@ Thank you for your interest in contributing!
 git clone git@github.com:marcstraube/zappzarapp-php-audit-logger.git
 cd zappzarapp-php-audit-logger
 make install
+make hooks
 ```
+
+## Git Hooks (Captainhook)
+
+Git hooks are managed via
+[Captainhook](https://captainhookphp.github.io/captainhook/).
+
+| Hook           | Actions                                            |
+| -------------- | -------------------------------------------------- |
+| `commit-msg`   | Validate Conventional Commits format               |
+| `pre-commit`   | Block secrets, PHP syntax check, CS-Fixer auto-fix |
+| `pre-push`     | Run all quality checks (`make check`)              |
+
+Hooks are configured in `captainhook.json`.
 
 ## Running Tests
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,7 @@ This package implements multiple security layers:
 - **Mutation Testing**: Infection for test quality assurance
 - **Automated Updates**: Dependabot for Composer + GitHub Actions
 - **CI/CD**: GitHub Actions with security checks on every push
+- **Signed Releases**: GPG-signed tags and commits
 
 ## Known Security Considerations
 


### PR DESCRIPTION
## Summary
- Extract GPG signature verification into dedicated `verify-signatures.yml` workflow (matches php-security pattern)
- Remove embedded GPG check from CI `tests` job (separation of concerns)
- Use GitHub App token (`marcstraube-release-bot`) for release-please to fix CI not triggering on release PRs
- Document Captainhook git hooks in CONTRIBUTING.md
- Add GPG-signed releases to SECURITY.md security measures

## Why
Release-please PRs created with `GITHUB_TOKEN` don't trigger CI workflows (GitHub restriction). This blocked release PR #26 (1.1.0). Using a GitHub App token fixes this.

## Test plan
- [x] All local quality checks pass (PHPStan, Psalm, PHPMD, Tests, Deptrac)
- [ ] CI passes on this PR
- [ ] After merge: release-please updates PR #26 with app token → CI triggers
- [ ] `Verify GPG Signatures` check appears in PR status

🤖 Generated with [Claude Code](https://claude.com/claude-code)