### PR TITLE
fix: add PHPStan ignore for PHP 8.5 protected(set) asymmetric visibility

### DIFF
--- a/tests/AuditLogEntryTest.php
+++ b/tests/AuditLogEntryTest.php
@@ -119,7 +119,7 @@ final class AuditLogEntryTest extends TestCase
         $this->expectException(Error::class);
         $this->expectExceptionMessage('Cannot modify readonly property');
 
-        // @phpstan-ignore property.readOnlyAssignOutOfClass
+        // @phpstan-ignore property.readOnlyAssignOutOfClass, assign.propertyProtectedSet
         $entry->action = 'modified.action';
     }
 

--- a/tests/AuditLogResultTest.php
+++ b/tests/AuditLogResultTest.php
@@ -125,7 +125,7 @@ final class AuditLogResultTest extends TestCase
         $this->expectException(Error::class);
         $this->expectExceptionMessage('Cannot modify readonly property');
 
-        // @phpstan-ignore property.readOnlyAssignOutOfClass
+        // @phpstan-ignore property.readOnlyAssignOutOfClass, assign.propertyProtectedSet
         $result->action = 'modified.action';
     }
 


### PR DESCRIPTION
## Summary
- Add `assign.propertyProtectedSet` to PHPStan ignore comments in readonly property mutation tests
- Required for compatibility with PHPStan 2.1.46+ which recognizes PHP 8.5 asymmetric visibility

## Context
Tests intentionally assign to readonly properties to verify immutability (`$entry->action = 'modified.action'`). PHPStan now also flags this as `assign.propertyProtectedSet` (PHP 8.5 feature). The ignore is permanent — these tests will always need it.

## Test plan
- [x] All local quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)