### PR TITLE
ci: add PHP setup and dependency install to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,17 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v6
 
+      - name: Setup PHP
+        if: ${{ steps.release.outputs.release_created }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+
+      - name: Install dependencies
+        if: ${{ steps.release.outputs.release_created }}
+        run: composer install --no-dev --prefer-dist --no-progress
+
       - name: Generate SBOM
         if: ${{ steps.release.outputs.release_created }}
         run: composer sbom


### PR DESCRIPTION
## Summary
- Add PHP setup and composer install steps to release workflow
- SBOM generation requires these to run `composer sbom`

## Context
v1.1.0 release failed to upload SBOM because the workflow was missing PHP/composer setup. SBOM will be uploaded manually for v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)