### PR TITLE
chore: add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # zappzarapp/audit-logger
 
+[![Latest Version](https://img.shields.io/packagist/v/zappzarapp/audit-logger.svg)](https://packagist.org/packages/zappzarapp/audit-logger)
+[![PHP Version](https://img.shields.io/packagist/php-v/zappzarapp/audit-logger.svg)](https://packagist.org/packages/zappzarapp/audit-logger)
+[![License](https://img.shields.io/packagist/l/zappzarapp/audit-logger.svg)](https://packagist.org/packages/zappzarapp/audit-logger)
+[![CI](https://github.com/marcstraube/zappzarapp-php-audit-logger/actions/workflows/ci.yml/badge.svg)](https://github.com/marcstraube/zappzarapp-php-audit-logger/actions/workflows/ci.yml)
+[![Socket Badge](https://badge.socket.dev/composer/package/zappzarapp/audit-logger)](https://socket.dev/composer/package/zappzarapp/audit-logger)
+
 GDPR-compliant audit logging for PHP with injectable encryption, configurable
 storage, and tamper-proof checksums.
 


### PR DESCRIPTION
## Summary
- Add Packagist (version, PHP version, license), CI, and Socket security badges to README
- Matches badge pattern from zappzarapp/security

🤖 Generated with [Claude Code](https://claude.com/claude-code)