### PR TITLE
ci: extract security audit into dedicated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,33 @@ jobs:
       - name: Run Psalm Taint Analysis
         run: vendor/bin/psalm --taint-analysis
 
+  security:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: openssl, pdo
+          tools: composer:v2
+
+      # Audits only runtime (non-dev) dependencies, mirroring the Node repo's
+      # `pnpm audit --prod`. This library ships no runtime Composer deps, so the
+      # set is empty today; `composer audit --no-dev` errors on an empty set
+      # ("No installed packages found"), hence the guard makes an empty set pass
+      # green like pnpm does. The audit runs automatically once runtime deps exist.
+      - name: Security audit (runtime dependencies)
+        run: |
+          if [ -n "$(composer show --locked --no-dev 2>/dev/null)" ]; then
+            composer audit --locked --no-dev
+          else
+            echo "No runtime dependencies to audit."
+          fi
+
   tests:
     name: PHP ${{ matrix.php }} Tests
     runs-on: ubuntu-latest
@@ -74,9 +101,6 @@ jobs:
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
-
-      - name: Security audit
-        run: composer audit --no-dev
 
       - name: Check code style
         run: vendor/bin/php-cs-fixer fix --dry-run --diff


### PR DESCRIPTION
## Problem

The `Security audit` step (`composer audit --no-dev`) was failing on every CI run, surfaced by Dependabot PR #48 (PHP 8.4 & 8.5 jobs red):

```
Run composer audit --no-dev
No installed packages found. Please run "composer install" before running "audit" or pass "--locked" to audit the lock file.
##[error]Process completed with exit code 1.
```

The cause is structural, not the dependency bumps: this library has **no runtime Composer dependencies** (`require` is just `php` + `ext-pdo`, which are platform constraints). With `--no-dev` the package set is empty, and newer Composer versions treat an empty set as an error (exit 1). Master was only green because its last run predates the Composer version that changed this behaviour — a re-run would fail too.

## Change

- Extract the audit into a dedicated `security` job, mirroring the [Node repo](https://github.com/marcstraube/zappzarapp-node-audit-logger)'s standalone `security` job. It now runs **once** instead of redundantly per PHP version.
- Guard the empty non-dev set so it passes green like Node's `pnpm audit --prod` (the Node package has no runtime deps either, and pnpm exits 0 on an empty set where Composer errors). The audit runs automatically once runtime deps exist.

Scope `--no-dev` deliberately matches Node's `--prod`: only dependencies that reach consumers of the library are CI-blocking; the dev toolchain is already covered by Dependabot, Socket, GitGuardian, CodeQL and Psalm Taint.

## Follow-up

Once merged, comment `@dependabot rebase` on #48 — CI then goes green and auto-merge takes over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)