### PR TITLE
ci: share security audit between composer and CI via one script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,18 +55,11 @@ jobs:
           extensions: openssl, pdo
           tools: composer:v2
 
-      # Audits only runtime (non-dev) dependencies, mirroring the Node repo's
-      # `pnpm audit --prod`. This library ships no runtime Composer deps, so the
-      # set is empty today; `composer audit --no-dev` errors on an empty set
-      # ("No installed packages found"), hence the guard makes an empty set pass
-      # green like pnpm does. The audit runs automatically once runtime deps exist.
+      # Runs scripts/security-audit.sh via composer, the single source of truth
+      # shared with the local `composer security` / `composer check`. See that
+      # script for why an empty non-dev set must be guarded.
       - name: Security audit (runtime dependencies)
-        run: |
-          if [ -n "$(composer show --locked --no-dev 2>/dev/null)" ]; then
-            composer audit --locked --no-dev
-          else
-            echo "No runtime dependencies to audit."
-          fi
+        run: composer security
 
   tests:
     name: PHP ${{ matrix.php }} Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+GDPR-konformer Audit-Logger für PHP (Library, `zappzarapp/audit-logger`).
+
+## Schwesterprojekt — konsistent halten
+
+`zappzarapp-node-audit-logger` ist das Node/TypeScript-Pendant mit gleichem Funktionsumfang.
+Bei Änderungen an CI, Tooling-Philosophie oder Projektstruktur immer das jeweils
+andere Repo abgleichen, damit beide in Aussage und Aufbau gleich bleiben.
+
+Beispiel: Der Security-Audit liegt in beiden Repos in einem **eigenen `security`-CI-Job**
+(nicht inline in der Test-Matrix). PHP `composer audit --no-dev` entspricht bewusst
+Nodes `pnpm audit --prod`: nur Runtime-/Produktiv-Deps sind CI-blockierend, die
+dev-Toolchain ist über Dependabot, Socket, GitGuardian, CodeQL und Psalm Taint abgedeckt.
+
+## Composer-Audit-Falle (wichtig)
+
+Diese Library hat **keine Runtime-Composer-Dependencies** — `require` ist nur
+`php` + `ext-pdo` (Plattform-Constraints, keine Pakete). Daher ist die non-dev-Paketmenge
+leer, und Composer bricht bei einer leeren Menge ab:
+
+```
+composer audit --no-dev
+> No installed packages found. ... (exit 1)
+```
+
+`--locked --no-dev` hilft hier **nicht** (Composer fällt bei leerer non-dev-Menge auf
+den installed-Pfad zurück). Lösung: vorher prüfen, ob es überhaupt Runtime-Deps gibt,
+und die leere Menge wie Nodes `pnpm audit --prod` grün durchlaufen lassen.
+
+Diese Guard-Logik lebt in **`scripts/security-audit.sh`** als *Single Source of Truth*:
+Sowohl das composer-Script `security` (`bash scripts/security-audit.sh`, aufgerufen von
+`composer check`/`check-full`) als auch der CI-Job `security` (`run: composer security`)
+führen dieses eine Script aus — lokale und CI-Checks können also nicht auseinanderlaufen.
+Bei Änderungen an der Audit-Logik nur dieses Script anfassen.
+
+## Konventionen
+
+- Conventional Commits (`type(scope): message`), z. B. `ci:`, `chore(deps-dev):`.
+- Commits müssen **GPG-signiert** sein (CI-Job `Verify GPG Signatures` erzwingt das).
+- Dependabot-PRs für dev-Deps werden gruppiert (`.github/dependabot.yml`, wöchentlich)
+  und nach grünem CI automatisch gemergt.

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
     "cs-check": "@php vendor/bin/php-cs-fixer fix --dry-run --diff",
     "psalm": "@php vendor/bin/psalm --show-info=false",
     "psalm-taint": "@php vendor/bin/psalm --taint-analysis",
-    "security": "composer audit --no-dev",
+    "security": "bash scripts/security-audit.sh",
     "check": [
       "@security",
       "@cs-check",

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Security audit of runtime (non-dev) dependencies, mirroring the Node repo's
+# `pnpm audit --prod`. This library ships no runtime Composer deps (`require` is
+# just php + ext-pdo), so the non-dev set is empty. `composer audit --no-dev`
+# errors on an empty set ("No installed packages found", exit 1), and
+# `--locked --no-dev` does not help (Composer falls back to the installed path
+# on an empty non-dev set). Guard so an empty set passes green like pnpm does;
+# the audit runs automatically once runtime deps exist.
+#
+# Single source of truth: both the `composer security` script and the CI
+# `security` job run this file, so local and CI checks can never drift.
+set -euo pipefail
+
+if [ -n "$(composer show --locked --no-dev 2>/dev/null)" ]; then
+  composer audit --locked --no-dev
+else
+  echo "No runtime dependencies to audit."
+fi


### PR DESCRIPTION
## Problem

Follow-up to #49. That PR fixed the CI audit step, but the **`composer security` script** (`composer audit --no-dev`) still has the same flaw — and it's run by `composer check` / `composer check-full`, so **local checks fail**:

```
composer security
> No installed packages found. ... (exit 1)
> Script composer audit --no-dev handling the security event returned with error code 1
```

Root cause is the same as #49: this library has no runtime Composer deps (`require` = `php` + `ext-pdo`), so the non-dev set is empty and `composer audit --no-dev` errors on it.

## Change

Single source of truth instead of duplicating the guard logic:

- Extract the guarded audit into **`scripts/security-audit.sh`** (mirrors Node's `pnpm audit --prod`: only runtime deps are blocking, empty set passes green).
- Point the composer `security` script at it (`bash scripts/security-audit.sh`).
- CI `security` job now runs `composer security` instead of an inline guard.

Local and CI checks now run the exact same script and can't drift. Also adds **`CLAUDE.md`** documenting the audit pitfall and the consistency goal with the [Node sister-repo](https://github.com/marcstraube/zappzarapp-node-audit-logger).

## Verification

- `composer security` -> `No runtime dependencies to audit.` (exit 0)
- `composer validate` OK, `shellcheck scripts/security-audit.sh` clean, YAML valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)